### PR TITLE
setting version with '=' instead of '||='

### DIFF
--- a/lib/mustermann/version.rb
+++ b/lib/mustermann/version.rb
@@ -1,3 +1,3 @@
 module Mustermann
-  VERSION ||= '0.4.3'
+  VERSION = '0.4.3'
 end


### PR DESCRIPTION
We are trying to make a debian package for this gem, but gem2deb has a problem with '||=' and using '=' fixed it. Could you accept this PR? Otherwise I would have to update the patch at every single new upstream release. Thank you :)

Signed-off-by: Lucas Severo lucassalves65@gmail.com
